### PR TITLE
Label modif

### DIFF
--- a/arxiv2bib.py
+++ b/arxiv2bib.py
@@ -173,8 +173,15 @@ class Reference(object):
 
     def bibtex(self):
         """BibTex string of the reference."""
-
-        label = self.authors[0].split()[-1] + self.year + self.title.split()[0]
+        
+        label = self.authors[0].split()[-1] + self.year
+        
+        stop_words = {'A', 'The'}
+        if self.title.split()[0] in stop_words:
+            label += re.sub('[^A-Za-z]+', '', self.title.split()[1])
+        else:
+            label += re.sub('[^A-Za-z]+', '', self.title.split()[0])
+            
         lines = ["@article{" + label.lower()]
         for k, v in [("Author", " and ".join(self.authors)),
                     ("Title", self.title),

--- a/arxiv2bib.py
+++ b/arxiv2bib.py
@@ -174,7 +174,8 @@ class Reference(object):
     def bibtex(self):
         """BibTex string of the reference."""
 
-        lines = ["@article{" + self.id]
+        label = self.authors[0].split()[-1] + self.year + self.title.split()[0]
+        lines = ["@article{" + label.lower()]
         for k, v in [("Author", " and ".join(self.authors)),
                     ("Title", self.title),
                     ("Eprint", self.id),

--- a/tests/test_arxiv2bib.py
+++ b/tests/test_arxiv2bib.py
@@ -189,7 +189,8 @@ class testArxiv2Bib(unittest.TestCase):
         self.assertEqual(self.frv.month, 'May')
 
     def test_form_bibtex(self):
-        self.assertEqual(self.frv.bibtex()[:21], '@article{1205.1001v1,')
+        expected = '@article{fischer2012membrane,'
+        self.assertEqual(self.frv.bibtex()[:len(expected)], expected)
 
     def test_reference_error_info(self):
         r = self.not_found
@@ -241,8 +242,8 @@ class testCLI(unittest.TestCase):
 
     def test_output_messages(self):
         self.assertEqual(len(self.vanilla.output), 1)
-        expected = '@article{1001.1001v1,\nAuthor        = {Philip G. Judge}'
-        self.assertEqual(self.vanilla.output[0][:55], expected)
+        expected = '@article{judge2010chromosphere,\nAuthor        = {Philip G. Judge}'
+        self.assertEqual(self.vanilla.output[0][:len(expected)], expected)
 
     def test_tally_errors(self):
         self.assertEqual(self.no_errors.code, 0)


### PR DESCRIPTION
In the new way of generating bibtex references, arxiv uses first_author_name+year+first_nonstop_word. I modified the code to generate it the same way 